### PR TITLE
Adds HELP/TYPE output and epoch in seconds (instead of ms)

### DIFF
--- a/lib/puppet/reports/prometheus.rb
+++ b/lib/puppet/reports/prometheus.rb
@@ -57,7 +57,21 @@ Puppet::Reports.register_report(:prometheus) do
     epochtime = DateTime.now.new_offset(0).strftime('%Q')
     new_metrics["puppet_report{#{common_values.join(',')}}"] = epochtime
 
+    definitons = <<-EOS
+# HELP puppet_report Unix timestamp (in ms) of the last puppet run
+# TYPE puppet_report gauge
+# HELP puppet_report_changes Changed resources in the last puppet run
+# TYPE puppet_report_changes gauge
+# HELP puppet_report_events Puppet events TODO: explain better
+# TYPE puppet_report_events gauge
+# HELP puppet_report_resources Puppet ressources break down by their state
+# TYPE puppet_report_resources gauge
+# HELP puppet_report_time Puppet ressource apply time broken down by their type
+# TYPE puppet_report_time gauge
+EOS
+
     File.open(filename, 'w') do |file|
+      file.write(definitons)
       if File.exist?(yaml_filename)
         file.write("# Old metrics\n")
         existing_metrics = YAML.load_file(yaml_filename)

--- a/lib/puppet/reports/prometheus.rb
+++ b/lib/puppet/reports/prometheus.rb
@@ -54,11 +54,11 @@ Puppet::Reports.register_report(:prometheus) do
       end
     end
 
-    epochtime = DateTime.now.new_offset(0).strftime('%Q')
+    epochtime = DateTime.now.new_offset(0).strftime('%Q')/1000.0
     new_metrics["puppet_report{#{common_values.join(',')}}"] = epochtime
 
     definitons = <<-EOS
-# HELP puppet_report Unix timestamp (in ms) of the last puppet run
+# HELP puppet_report Unix timestamp of the last puppet run
 # TYPE puppet_report gauge
 # HELP puppet_report_changes Changed resources in the last puppet run
 # TYPE puppet_report_changes gauge


### PR DESCRIPTION
This adds the missing `HELP` and `TYPE` lines in the output. They should be otherwise you will run into problems with multiple nodes reporting into the same node_exporter daemon.

Tested with node_exporter 0.14.0

Modified epoch to be seconds (everything in prometheus should be in SI base units

Fixes #9 