### PR TITLE
don't add .prom if report_filename is set.

### DIFF
--- a/lib/puppet/reports/prometheus.rb
+++ b/lib/puppet/reports/prometheus.rb
@@ -30,13 +30,13 @@ Puppet::Reports.register_report(:prometheus) do
 
   def process
     namevar = if REPORT_FILENAME.nil?
-                host
+                host + '.prom'
               else
                 REPORT_FILENAME
               end
 
     yaml_filename = File.join(TEXTFILE_DIRECTORY, '.' + namevar + '.yaml')
-    filename = File.join(TEXTFILE_DIRECTORY, namevar + '.prom')
+    filename = File.join(TEXTFILE_DIRECTORY, namevar)
 
     common_values = {
       environment: environment,


### PR DESCRIPTION
we enforce setting the report_filename to something ending
with .prom already. If we add another .prom, we end up with
filenames like somethin.prom.prom.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
