### PR TITLE
Remove metric files for nodes that haven't sent reports in X time

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Configuration options include:
 - `report_filename` - [String] If specified, saves all reports to a single file (must end with .prom)
 - `environments` - [Array] If specified, only creates metrics on reports from these environments
 - `reports` - [Array] If specified, only creates metrics from reports of this type (changes, events, resources, time)
+- `stale_time` - [Integer] If specified, delete metric files for nodes that haven't sent reports in X days
 
 Include `prometheus` in your Puppet reports configuration; enable pluginsync:
 


### PR DESCRIPTION
#### Pull Request (PR) description
Extends the configuration file by allowing the user to specify a `stale_time` in days. It is then evaluated against all of the `*.prom` file modification dates (date of the last received report). Files that exceed the number of days specified are then removed.

#### This Pull Request (PR) fixes the following issues
Since a more advanced implementation would require some integrations with PuppetDB, this might potentially resolve #38 to some extent.