### PR TITLE
Feature/report puppet transaction completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ puppet_report_events{name="Failure",environment="production",host="node.example.
 puppet_report_events{name="Success",environment="production",host="node.example.com"} 0
 puppet_report_events{name="Total",environment="production",host="node.example.com"} 0
 puppet_report{environment="production",host="node.example.com"} 1477054915347
+puppet_transaction_completed{environment="production",host="node.example.com"} 1
 ```
 
 ## Contributors

--- a/lib/puppet/reports/prometheus.rb
+++ b/lib/puppet/reports/prometheus.rb
@@ -89,6 +89,15 @@ EOS
 # TYPE puppet_report gauge
 EOS
 
+    if defined?(transaction_completed) && ([true, false].include? transaction_completed)
+      completed = transaction_completed == true ? 1 : 0
+      new_metrics["puppet_transaction_completed{#{common_values.join(',')}}"] = completed
+      definitions << <<-EOS
+# HELP puppet_transaction_completed transaction completed status of the last puppet run
+# TYPE puppet_transaction_completed gauge
+EOS
+    end
+
     File.open(filename, 'w') do |file|
       file.write(definitions)
       if File.exist?(yaml_filename)


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a metric indicating if the puppet transaction has completed, based on the report variable 'transaction_completed'.

This is useful for knowing if the catalog compilation failed on the master.

#### This Pull Request (PR) fixes the following issues
n/a
