### PR TITLE
Add cache_catalog_status and puppet_status metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ puppet_report_events{name="Success",environment="production",host="node.example.
 puppet_report_events{name="Total",environment="production",host="node.example.com"} 0
 puppet_report{environment="production",host="node.example.com"} 1477054915347
 puppet_transaction_completed{environment="production",host="node.example.com"} 1
-puppet_cache_catalog_status{environment="production",host="node.example.com"} 2
+puppet_cache_catalog_status{state="not_used",environment="production",host="node.example.com"} 0
+puppet_cache_catalog_status{state="explicitly_requested",environment="production",host="node.example.com"} 1
+puppet_cache_catalog_status{state="on_failure",environment="production",host="node.example.com"} 0
 ```
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ puppet_report_events{name="Success",environment="production",host="node.example.
 puppet_report_events{name="Total",environment="production",host="node.example.com"} 0
 puppet_report{environment="production",host="node.example.com"} 1477054915347
 puppet_transaction_completed{environment="production",host="node.example.com"} 1
+puppet_cache_catalog_status{environment="production",host="node.example.com"} 2
 ```
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ puppet_transaction_completed{environment="production",host="node.example.com"} 1
 puppet_cache_catalog_status{state="not_used",environment="production",host="node.example.com"} 0
 puppet_cache_catalog_status{state="explicitly_requested",environment="production",host="node.example.com"} 1
 puppet_cache_catalog_status{state="on_failure",environment="production",host="node.example.com"} 0
+puppet_status{state="failed",environment="production",host="node.example.com"} 0
+puppet_status{state="changed",environment="production",host="node.example.com"} 0
+puppet_status{state="unchanged",environment="production",host="node.example.com"} 1
 ```
 
 ## Contributors

--- a/lib/puppet/reports/prometheus.rb
+++ b/lib/puppet/reports/prometheus.rb
@@ -98,6 +98,22 @@ EOS
 EOS
     end
 
+    if defined?(cached_catalog_status) && (['not_used', 'explicitly_requested', 'on_failure'].include? cached_catalog_status)
+      case cached_catalog_status
+      when 'not_used'
+        cached_catalog_status_value = 0
+      when 'explicitly_requested'
+        cached_catalog_status_value = 1
+      when 'on_failure'
+        cached_catalog_status_value = 2
+      end
+      new_metrics["puppet_cache_catalog_status{#{common_values.join(',')}}"] = cached_catalog_status_value
+      definitions << <<-EOS
+# HELP puppet_cache_catalog_status whether a cached catalog was used in the run, and if so, the reason that it was used (0 - not used, 1 - explicitly requested, 2 - on failure).
+# TYPE puppet_cache_catalog_status gauge
+EOS
+    end
+
     File.open(filename, 'w') do |file|
       file.write(definitions)
       if File.exist?(yaml_filename)

--- a/lib/puppet/reports/prometheus.rb
+++ b/lib/puppet/reports/prometheus.rb
@@ -98,18 +98,21 @@ EOS
 EOS
     end
 
-    if defined?(cached_catalog_status) && (['not_used', 'explicitly_requested', 'on_failure'].include? cached_catalog_status)
+    cached_catalog_state = [0, 0, 0]
+    if defined?(cached_catalog_status) && (%w[not_used explicitly_requested on_failure].include? cached_catalog_status)
       case cached_catalog_status
       when 'not_used'
-        cached_catalog_status_value = 0
+        cached_catalog_state[0] = 1
       when 'explicitly_requested'
-        cached_catalog_status_value = 1
+        cached_catalog_state[1] = 1
       when 'on_failure'
-        cached_catalog_status_value = 2
+        cached_catalog_state[2] = 1
       end
-      new_metrics["puppet_cache_catalog_status{#{common_values.join(',')}}"] = cached_catalog_status_value
+      new_metrics["puppet_cache_catalog_status{state=\"not_used\",#{common_values.join(',')}}"] = cached_catalog_state[0]
+      new_metrics["puppet_cache_catalog_status{state=\"explicitly_requested\",#{common_values.join(',')}}"] = cached_catalog_state[1]
+      new_metrics["puppet_cache_catalog_status{state=\"on_failure\",#{common_values.join(',')}}"] = cached_catalog_state[2]
       definitions << <<-EOS
-# HELP puppet_cache_catalog_status whether a cached catalog was used in the run, and if so, the reason that it was used (0 - not used, 1 - explicitly requested, 2 - on failure).
+# HELP puppet_cache_catalog_status whether a cached catalog was used in the run, and if so, the reason that it was used
 # TYPE puppet_cache_catalog_status gauge
 EOS
     end

--- a/lib/puppet/reports/prometheus.rb
+++ b/lib/puppet/reports/prometheus.rb
@@ -117,6 +117,26 @@ EOS
 EOS
     end
 
+    # Set initial status
+    status_state = [0, 0, 0]
+    if defined?(status) && (%w[failed changed unchanged].include? status)
+      case status
+      when 'failed'
+        status_state[0] = 1
+      when 'changed'
+        status_state[1] = 1
+      when 'unchanged'
+        status_state[2] = 1
+      end
+      new_metrics["puppet_status{state=\"failed\",#{common_values.join(',')}}"] = status_state[0]
+      new_metrics["puppet_status{state=\"changed\",#{common_values.join(',')}}"] = status_state[1]
+      new_metrics["puppet_status{state=\"unchanged\",#{common_values.join(',')}}"] = status_state[2]
+      definitions << <<-EOS
+# HELP puppet_status the status of the client run
+# TYPE puppet_status gauge
+EOS
+    end
+
     File.open(filename, 'w') do |file|
       file.write(definitions)
       if File.exist?(yaml_filename)


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

#### Pull Request (PR) description

This PR adds [cache_catalog_status](https://puppet.com/docs/puppet/5.5/format_report.html) metric. Default value for `usecacheonfailure` configuration key is `true`, so puppet uses cached manifest if it fails to collect it from the server.

This metric helps to detect such cases. Example of error: 

> Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Class[Mariadb]: parameter 'service_ensure' expects a match for Stdlib::Ensure::Service = Enum['running', 'stopped'], got Boolean (file: /etc/puppetlabs/code/environments/production/manifests/node.example.com.pp, line: 24, column: 3) on node node.example.com

In this case, the only metric, that we can use to alert is `cache_catalog_status `, which turns from 0 (not_used) to 2 (on_failure).