### PR TITLE
reports: Update to use report_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ textfile_directory: /var/lib/prometheus-dropzone
 
 Configuration options include:
 - `textfile_directory` - [String] Location of the node_exporter `collector.textfile.directory` (Required)
-- `report_filename` - [String] If specified, saves all reports to a single file (must end with .prom)
+- `report_prefix` - [String] the prefix to add to the prometheus reprots.  By default this is `puppet_report_`.
 - `environments` - [Array] If specified, only creates metrics on reports from these environments
 - `reports` - [Array] If specified, only creates metrics from reports of this type (changes, events, resources, time)
 - `stale_time` - [Integer] If specified, delete metric files for nodes that haven't sent reports in X days


### PR DESCRIPTION
This commit removes the report_filename config parameter and adds a report_prefix parameter.  AFAICT the current code suggests that it will write all host data to the same file.  However the code writes the old data to the prom file giving all values -1 which is incorrect

I looked at why this was and i can't find much information on the original issue[1] and PR[2].  further to this the current implementation is very racy if one sets REPORT_FILENAME

This also updates the clean stale function to only act on files with the report_prefix and avoid deleting files which may have been placed there by none puppetserver process

more then happy to split this up into separate patches but wanted to get a bit more feedback on why things got set to -1 and if im missing something

[1]https://github.com/voxpupuli/puppet-prometheus_reporter/pull/5 [2]https://github.com/voxpupuli/puppet-prometheus_reporter/pull/7
