### PR TITLE
remove supported operating systems from metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,34 +7,6 @@
   "source": "https://github.com/voxpupuli/puppet-prometheus_reporter",
   "project_page": "https://github.com/voxpupuli/puppet-prometheus_reporter",
   "issues_url": "https://github.com/voxpupuli/puppet-prometheus_reporter/issues",
-  "operatingsystem_support": [
-    {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8"
-      ]
-    },
-    {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
-    }
-  ],
   "requirements": [
     {
       "name": "puppet",


### PR DESCRIPTION
there is no os dependent code or tests in ths module, so the supported operating systems metadata is not needed
